### PR TITLE
Remove extract fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2021-12-16
+## [0.0.9] - 2021-12-16
 ### Added
 - Initiated repo
 - Added WDL, subworkflows and imports from crosscheckFingerprintsCollector; will extend to process alignments for other fingerprinting methods
@@ -20,3 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - The "extractFingerprint" task.
+
+## [1.0.1] 2022-03-8
+### Added
+None
+
+### Changed
+- runFinCreator task command use separate python file in src/
+
+### Removed
+None
+

--- a/hotspotFingerprintCollector.wdl
+++ b/hotspotFingerprintCollector.wdl
@@ -374,7 +374,7 @@ parameter_meta {
 }
 
 command {
- python3 src/fincreator.py ~{inputVcf} ~{inputCoverage} ~{hotspotSNPs} ~{sampleID} ~{sep='\",\"' chroms}
+ python3 /.mounts/labs/gsi/testdata/hotspotFingerprintCollector/input_data/src/fincreator.py ~{inputVcf} ~{inputCoverage} ~{hotspotSNPs} ~{sampleID} ~{sep='\",\"' chroms}
 }
 
 runtime {

--- a/hotspotFingerprintCollector.wdl
+++ b/hotspotFingerprintCollector.wdl
@@ -374,7 +374,7 @@ parameter_meta {
 }
 
 command {
- python3 /src/fincreator.py ~{inputVcf} ~{inputCoverage} ~{hotspotSNPs} ~{sampleID} ~{sep='\",\"' chroms}
+ python3 src/fincreator.py ~{inputVcf} ~{inputCoverage} ~{hotspotSNPs} ~{sampleID} ~{sep='\",\"' chroms}
 }
 
 runtime {


### PR DESCRIPTION
Isolating the python code in runFincreator to separator python file in /src. Last time did this didn't generate fingerprint because the fastq inputs low coverage. Here used absolute path for /src, because relative path failed.