### PR TITLE
Pool bamindex bwa mem star

### DIFF
--- a/hotspotFingerprintCollector.wdl
+++ b/hotspotFingerprintCollector.wdl
@@ -126,8 +126,8 @@ workflow hotspotFingerprintCollector {
      }
 
     meta {
-     author: "Lawrence Heisler"
-     email: "lawrence.heisler@oicr.on.ca"
+     author: "Lawrence Heisler and Gavin Peng"
+     email: "lawrence.heisler@oicr.on.ca and gpeng@oicr.on.ca"
      description: "fingerprintsCollector, workflow that generates aligns reads to reference, then creates fingerprints using variousmethods. Output are fingerprints of various types and coverage statistics from the alignment\n##"
      dependencies: [
       {

--- a/imports/pull_bwaMem.wdl
+++ b/imports/pull_bwaMem.wdl
@@ -208,7 +208,7 @@ workflow bwaMem {
     }
 
     output {
-        File bwaMemBam = bamMerge.outputMergedBam
+        File bwaMemBam = indexBam.outputBam
         File bwaMemIndex = indexBam.outputBai
         File? log = adapterTrimmingLog.summaryLog
         File? cutAdaptAllLogs = adapterTrimmingLog.allLogs
@@ -480,10 +480,12 @@ task indexBam {
     }
 
     String resultBai = "~{basename(inputBam)}.bai"
+    String resultBam = "~{basename(inputBam)}.bam"
 
     command <<<
         set -euo pipefail
         samtools index ~{inputBam} ~{resultBai}
+        cp ~{inputBam} ~{resultBam}
     >>>
 
     runtime {
@@ -494,11 +496,13 @@ task indexBam {
 
     output {
         File outputBai = "~{resultBai}"
+        File outputBam = "~{resultBam}"
     }
 
     meta {
         output_meta: {
-            outputBai: "output index file for bam aligned to genome"
+            outputBai: "output index file for bam aligned to genome",
+            outputBam: "copied input bam file"
         }
     }
 
@@ -617,5 +621,3 @@ task adapterTrimmingLog {
     }
 
 }
- 
-

--- a/imports/pull_star.wdl
+++ b/imports/pull_star.wdl
@@ -151,7 +151,7 @@ workflow star {
 }
 
 output {
-  File starBam          = runStar.outputBam
+  File starBam          = indexBam.outputBam
   File starIndex        = indexBam.outputBai
   File transcriptomeBam = runStar.transcriptomeBam
   File starChimeric     = runStar.outputChimeric
@@ -320,12 +320,14 @@ parameter_meta {
  modules:   "modules for running indexing job"
  timeout:   "hours before task timeout"
 }
+String resultBam = "~{basename(inputBam, '.bam')}.bam"
 
 command <<<
  java -Xmx~{jobMemory-6}G -jar $PICARD_ROOT/picard.jar BuildBamIndex \
                               VALIDATION_STRINGENCY=LENIENT \
                               OUTPUT="~{basename(inputBam, '.bam')}.bai" \
                               INPUT=~{inputBam}
+ cp ~{inputBam} ~{resultBam}
 >>>
 
 runtime {
@@ -336,6 +338,7 @@ runtime {
 
 output {
   File outputBai = "~{basename(inputBam, '.bam')}.bai"
+  File outputBam = "~{resultBam}"
 }
 
 meta {


### PR DESCRIPTION
change bwaMem and star so that downstream workflow can have bam and bai inputs in same folder. This can fix bugs like downstream workflow can't find bam index.